### PR TITLE
SNAP-5: emulate CSS Media (screen|print)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ It will probably be necessary to use an app that helps you formulate and store c
 
 - `url` — (**required**) the URL you want to render
 - `output` — (default `pdf`) specify `png` if you want a PNG image or `pdf` for PDF
+- `media` — (default `screen`) specify a CSS Media. Only other option is `print`.
 - `user` — (optional) HTTP Basic Authentication username
 - `pass` — (optional) HTTP Basic Authentication password

--- a/app/app.js
+++ b/app/app.js
@@ -49,7 +49,7 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
 
 app.post('/snap', (req, res) => {
   let sizeHtml = 0;
-  let fnMedia = 'screen'; // assume ppl want WYSIWYG screenshots, not print CSS
+  let fnMedia = (req.query.media === 'print') ? 'print' : 'screen';
   let fnHtml = '';
   let fnOutput = (req.query.output === 'png') ? 'png' : 'pdf';
   let fnFormat = 'A4';
@@ -143,6 +143,9 @@ app.post('/snap', (req, res) => {
           await page.setContent(fnHtml);
         }
 
+        // Set CSS Media
+        await page.emulateMedia(fnMedia);
+
         // PNG or PDF?
         if (fnOutput === 'png') {
           pngOptions.path = fnPath;
@@ -158,11 +161,6 @@ app.post('/snap', (req, res) => {
             await page.screenshot(pngOptions);
           }
         } else {
-          // @media(print) is default for Puppeteer PDF generation
-          if (fnMedia === 'screen') {
-            await page.emulateMedia('screen');
-          }
-
           await page.pdf({ path: fnPath, format: fnFormat });
         }
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-5

Allow CSS Media to be set to either `screen` (default) or `print`. This is the media only, not a media query such as `(min-width: 768px)`.