### PR TITLE
SNAP-7: viewport dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ It will probably be necessary to use an app that helps you formulate and store c
 - `url` — (**required**) the URL you want to render
 - `output` — (default `pdf`) specify `png` if you want a PNG image or `pdf` for PDF
 - `media` — (default `screen`) specify a CSS Media. Only other option is `print`.
+- `width` — (default `800`) specify a pixel value for the viewport width.
+- `height` — (default `600`) specify a pixel value for the viewport height.
 - `user` — (optional) HTTP Basic Authentication username
 - `pass` — (optional) HTTP Basic Authentication password

--- a/app/app.js
+++ b/app/app.js
@@ -49,8 +49,10 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
 
 app.post('/snap', (req, res) => {
   let sizeHtml = 0;
-  let fnMedia = (req.query.media === 'print') ? 'print' : 'screen';
   let fnHtml = '';
+  let fnWidth = (req.query.width) ? Number(req.query.width) : 800;
+  let fnHeight = (req.query.height) ? Number(req.query.height) : 600;
+  let fnMedia = (req.query.media === 'print') ? 'print' : 'screen';
   let fnOutput = (req.query.output === 'png') ? 'png' : 'pdf';
   let fnFormat = 'A4';
   let fnPath = '';
@@ -142,6 +144,9 @@ app.post('/snap', (req, res) => {
         else {
           await page.setContent(fnHtml);
         }
+
+        // Set viewport dimensions
+        await page.setViewport({ width: fnWidth, height: fnHeight });
 
         // Set CSS Media
         await page.emulateMedia(fnMedia);


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-7

Set viewport width/height when generating a snap. For DOM fragment Snaps this is particularly useful to ensure that the user receives exactly what they saw on their screen.