### PR TITLE
SNAP-7: show something useful when sending 500

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -212,7 +212,7 @@ app.post('/snap', (req, res) => {
 
     if (err) {
       log.warn({ duration, inputSize: sizeHtml }, `Hardcopy generation failed for HTML ${fnHtml} in ${duration} seconds.`);
-      res.send(500, 'Error');
+      res.status(500).send(err);
     }
   });
 });


### PR DESCRIPTION
Follow-up to #4 — I tried setting a unit in my parameter and the thing just errored out with no advice on why. Maybe in the future we could provide more structured response codes but for now it at least gives you a reason in the response.