### PR TITLE
SNAP-9: allow pixel density to be set for Snaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ It will probably be necessary to use an app that helps you formulate and store c
 - `media` — (default `screen`) specify a CSS Media. Only other option is `print`.
 - `width` — (default `800`) specify a pixel value for the viewport width.
 - `height` — (default `600`) specify a pixel value for the viewport height.
+- `scale` — (default `2`) specify a device scale (pixel density) to control resolution of PNG output.
 - `user` — (optional) HTTP Basic Authentication username.
 - `pass` — (optional) HTTP Basic Authentication password.

--- a/app/app.js
+++ b/app/app.js
@@ -61,6 +61,7 @@ app.post('/snap', (req, res) => {
   const fnAuthPass = req.query.pass || '';
   const fnFragment = req.query.frag || '';
   const fnFullPage = (fnFragment) ? false : true;
+  const fnScale = Number(req.query.scale) || 2;
   const fnUrl = req.query.url || false;
 
   let fnHtml = '';
@@ -150,7 +151,7 @@ app.post('/snap', (req, res) => {
         }
 
         // Set viewport dimensions
-        await page.setViewport({ width: fnWidth, height: fnHeight });
+        await page.setViewport({ width: fnWidth, height: fnHeight, deviceScaleFactor: fnScale });
 
         // Set CSS Media
         await page.emulateMedia(fnMedia);


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-9

PR allows the device pixel density to be set, and the new default is `2` instead of `1` — this produces "retina" screenshots by default which is the conservative action, allowing people to downsample if necessary. Can't add resolution after the fact and people will want to share sharp, beautiful graphics.