### PR TITLE
SNAP-15: custom header text

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ It will probably be necessary to use an app that helps you formulate and store c
 - `logo` — (optional) Display your site's logo in the header area of each page on your PDF. See [Custom Logos](#custom-logos) section for instructions on adding your logo to this repository.
 - `user` — (optional) HTTP Basic Authentication username.
 - `pass` — (optional) HTTP Basic Authentication password.
+- `headerTitle` — (optional) Specify a Header Title for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
+- `headerSubtitle` — (optional) Specify a Header Subtitle for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
+- `headerDescription` — (optional) Specify a Header Description for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 
 We do our best to validate your input. When found to be invalid, we return **HTTP 422 Unprocessable Entity** and the response body will be a JSON object containing all failed validations.
 

--- a/app/app.js
+++ b/app/app.js
@@ -24,6 +24,7 @@ const puppeteer = require('puppeteer');
 const moment = require('moment');
 const mime = require('mime-types');
 const imgSize = require('image-size');
+const he = require('he');
 const log = require('./log');
 
 // We don't set this as a variable because it defines its own vars inside
@@ -76,6 +77,9 @@ app.post('/snap', [
   query('user', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
+  query('headerTitle', 'Must be an alphanumeric string').optional().isAscii(),
+  query('headerSubtitle', 'Must be an alphanumeric string').optional().isAscii(),
+  query('headerDescription', 'Must be an alphanumeric string').optional().isAscii(),
 ], (req, res) => {
   // debug
   console.log('🔗', require('url').parse(req.url).query);
@@ -104,6 +108,9 @@ app.post('/snap', [
   const fnSelector = req.query.selector || '';
   const fnFullPage = (fnSelector) ? false : true;
   const fnLogo = req.query.logo || false;
+  const fnHeaderTitle = req.query.headerTitle || '';
+  const fnHeaderSubtitle = req.query.headerSubtitle || '';
+  const fnHeaderDescription = req.query.headerDescription || '';
 
   let fnHtml = '';
 
@@ -173,8 +180,12 @@ app.post('/snap', [
               </div>
             </footer>
             <style type="text/css">
-              .pdf-footer {
+              .pdf-footer,
+              .pdf-footer * {
                 box-sizing: border-box;
+              }
+
+              .pdf-footer {
                 width: 100%;
                 font-size: 12px;
                 margin: 0 16px;
@@ -195,25 +206,54 @@ app.post('/snap', [
           const pdfLogoFile = 'logos/' + logos[fnLogo].filename;
           const pdfLogoData = new Buffer(fs.readFileSync(pdfLogoFile, 'binary'));
           const pdfLogoEncoded = `data:${mime.lookup(pdfLogoFile)};base64,${pdfLogoData.toString('base64')}`;
-          pdfOptions.margin.top = imgSize(pdfLogoFile).height + 32;
+          pdfOptions.margin.top = imgSize(pdfLogoFile).height + 84;
           pdfOptions.headerTemplate = `
             <header class="pdf-header">
+              <div class="pdf-header__meta">
+                <div class="pdf-header__title">${he.encode(fnHeaderTitle)}</div>
+                <div class="pdf-header__subtitle">${he.encode(fnHeaderSubtitle)}</div>
+                <div class="pdf-header__description">${he.encode(fnHeaderDescription)}</div>
+              </div>
               <div class="pdf-header__logo-wrapper">
                 <img src="${pdfLogoEncoded}" alt="logo" class="pdf-header__logo">
               </div>
             </header>
             <style type="text/css">
+              .pdf-header,
+              .pdf-header * {
+                box-sizing: border-box;
+              }
+
               .pdf-header {
                 position: relative;
                 z-index: 1000;
-                box-sizing: border-box;
                 width: 100%;
                 font-size: 12px;
-                margin: 0 16px;
+                margin: 0 5mm 5mm;
+                padding-bottom: 10px;
+                border-bottom: 2px solid #4c8cca;
                 white-space: nowrap;
+
+                display: grid;
+                grid-template-areas: "logo meta";
+                grid-template-columns: ${imgSize(pdfLogoFile).width}px 2fr;
               }
+
+              .pdf-header__meta {
+                grid-area: meta;
+                font-size: inherit;
+                padding-left: 10px;
+                margin-left: 10px;
+                border-left: 2px solid #4c8cca;
+              }
+              .pdf-header__title {
+                font-size: 16px;
+              }
+              .pdf-header__subtitle {}
+              .pdf-header__description {}
+
               .pdf-header__logo-wrapper {
-                text-align: right;
+                grid-area: logo;
               }
               .pdf-header__logo {
                 width: ${imgSize(pdfLogoFile).width}px;

--- a/app/app.js
+++ b/app/app.js
@@ -77,6 +77,9 @@ app.post('/snap', [
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
 ], (req, res) => {
+  // debug
+  console.log('🔗', require('url').parse(req.url).query);
+
   // Check for validation errors and return immediately if request was invalid.
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -236,7 +239,7 @@ app.post('/snap', [
         const page = await browser.newPage();
 
         // Set duration until Timeout
-        await page.setDefaultNavigationTimeout(30 * 1000);
+        await page.setDefaultNavigationTimeout(60 * 1000);
 
         // Use HTTP auth if needed (for testing staging envs)
         if (fnAuthUser && fnAuthPass) {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2490,6 +2490,11 @@
         }
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "bunyan": "^1.8.12",
     "express": "^4.16.3",
     "express-validator": "^5.3.0",
+    "he": "^1.2.0",
     "image-size": "^0.6.3",
     "method-override": "^3.0.0",
     "mime-types": "^2.1.20",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-15

Three new parameters to allow for custom Header text. Instead of accepting HTML/CSS we are opting for specific parameters that we can more tightly sanitize and style.

Full range of ASCII characters are considered valid input. This allows stuff like colons, dashes, and other common punctuation. We sanitize before printing to avoid arbitrary HTML or inline JS being injected.

Examples:
- What it should look like: [snap-15-normal.pdf](https://github.com/UN-OCHA/tools-snap-service/files/2501092/snap-15-normal.pdf)
- What a malicious request would look like: [snap-15-malicious.pdf](https://github.com/UN-OCHA/tools-snap-service/files/2501090/snap-15-malicious.pdf) (subtitle contains `<script>` which isn't executed because it was escaped)

