### PR TITLE
[DEV] Allow the service to run in dev mode via an env var (RUN_NODEMON=true)

### DIFF
--- a/debian-snapper-nodejs/run_node
+++ b/debian-snapper-nodejs/run_node
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv sh
-
 cd $NODE_APP_DIR
 
 # if $NODE_APP_DIR is empty, this will just spin up a lame nodejs instance
@@ -9,5 +8,10 @@ $(test "$(ls -A "$NODE_APP_DIR" 2>/dev/null)") || \
 echo "==> Installing npm dependencies"
 npm install
 
-echo "==> Starting the server"
-exec npm start
+if [ "$RUN_NODEMON" = "true" ]; then
+  echo "==> Starting the server with nodemon option for development and debug"
+  exec npm dev
+else
+  echo "==> Starting the server"
+  exec npm start
+fi


### PR DESCRIPTION
Needs a freshly built debian-snapper-nodejs image.