### PR TITLE
SNAP-16: optional custom footer text

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Shared service to generate PNG/PDF snapshots of our websites.
 - `headerTitle` — (optional) Specify a Header Title for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 - `headerSubtitle` — (optional) Specify a Header Subtitle for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 - `headerDescription` — (optional) Specify a Header Description for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
+- `footerText` — (optional) Specify custom Footer text for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 
 We do our best to validate your input. When found to be invalid, we return **HTTP 422 Unprocessable Entity** and the response body will be a JSON object containing all failed validations.
 

--- a/app/app.js
+++ b/app/app.js
@@ -77,9 +77,10 @@ app.post('/snap', [
   query('user', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
-  query('headerTitle', 'Must be an alphanumeric string').optional().isAscii(),
-  query('headerSubtitle', 'Must be an alphanumeric string').optional().isAscii(),
-  query('headerDescription', 'Must be an alphanumeric string').optional().isAscii(),
+  query('headerTitle', 'Must be an ASCII string').optional().isAscii(),
+  query('headerSubtitle', 'Must be an ASCII string').optional().isAscii(),
+  query('headerDescription', 'Must be an ASCII string').optional().isAscii(),
+  query('footerText', 'Must be an ASCII string').optional().isAscii(),
 ], (req, res) => {
   // debug
   console.log('🔗', require('url').parse(req.url).query);
@@ -111,6 +112,7 @@ app.post('/snap', [
   const fnHeaderTitle = req.query.headerTitle || '';
   const fnHeaderSubtitle = req.query.headerSubtitle || '';
   const fnHeaderDescription = req.query.headerDescription || '';
+  const fnFooterText = req.query.footerText || '';
 
   let fnHtml = '';
   let pngOptions = {};
@@ -178,8 +180,8 @@ app.post('/snap', [
                   Page <span class="pageNumber"></span> of <span class="totalPages"></span>
                 </div>
                 <div class="pdf-footer__right">
+                  <span class="pdf-footer__text">${fnFooterText}</span><br>
                   Date of Creation: <span>${moment().format('D MMM YYYY')}</span><br>
-                  <span class="url"></span><br>
                 </div>
               </footer>
               <style type="text/css">


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-16

Optional footer text. Replaces the hardcoded URL from before, since any website can send their own URL as the footer text.

Example: [SNAP-16-footer-text.pdf](https://github.com/UN-OCHA/tools-snap-service/files/2528837/SNAP-16-footer-text.pdf)
