### PR TITLE
OPS-5130: multiple requests don't crash process

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ It's possible to include your site's logo in the header of a PDF. First, make a 
 
 Once your PR has been deployed, you can activate your logo on PDF Snaps using the `logo` parameter (see [API](#api)) and the value you entered into `logos/_list.json`.
 
+### Custom Fonts
+
+It's possible to use a limited set of pre-approved custom fonts in your PDF header and footer. Similar to logos, if you'd like to use an a font not listed below, you can submit a PR to this repository in order to check the fonts into version control and expose the font to our server's Chrome instance.
+
+⚠️ **NOTE: the font MUST be open source.** The Snap Service is an open source repository and if your font's license is not open-source compatible then it cannot be included.
+
+Currently available fonts:
+
+- Roboto (v18)
+- Roboto Condensed (v16)
+
 ## Install / Develop
 
 The node container will do all the npm installation for you. No need to do it locally. Just run the Docker commands to get started.

--- a/app/app.js
+++ b/app/app.js
@@ -19,6 +19,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const methodOverride = require('method-override');
 const { query, validationResult } = require('express-validator/check');
+const url = require('url');
 
 const puppeteer = require('puppeteer');
 const moment = require('moment');
@@ -83,7 +84,7 @@ app.post('/snap', [
   query('footerText', 'Must be an ASCII string').optional().isAscii(),
 ], (req, res) => {
   // debug
-  console.log('🔗', require('url').parse(req.url).query);
+  log.info(url.parse(req.url).query);
 
   // Check for validation errors and return immediately if request was invalid.
   const errors = validationResult(req);
@@ -414,5 +415,5 @@ app.post('/snap', [
 });
 
 http.createServer(app).listen(app.get('port'), () => {
-  console.info('⚡️ Express server listening on port:', app.get('port'));
+  log.info('⚡️ Express server listening on port:', app.get('port'));
 });

--- a/app/app.js
+++ b/app/app.js
@@ -360,9 +360,8 @@ app.post('/snap', [
           // Note: page.evaluate() is a stringified injection into the runtime.
           //       any arguments you need inside this function block have to be
           //       explicitly passed instead of relying on closure.
-          await page.evaluate((snapType) => {
-            let dom = document.querySelector('html');
-            dom.classList.add(`snap--${snapType}`);
+          await page.evaluate((snapOutput) => {
+            document.documentElement.classList.add(`snap--${snapOutput}`);
           }, fnOutput);
 
           // Output PNG or PDF?

--- a/app/app.js
+++ b/app/app.js
@@ -49,9 +49,10 @@ const allowedFormats = ['Letter', 'Legal', 'Tabloid', 'Ledger', 'A0', 'A1', 'A2'
 // but (just like a normal web browser) we only want one. We'll open a new "tab"
 // each time our `/snap` route is invoked by reusing the established connection.
 let browserWSEndpoint = '';
-let browser;
 
 async function connectPuppeteer() {
+  let browser;
+
   if (browserWSEndpoint) {
     browser = await puppeteer.connect({browserWSEndpoint});
   }
@@ -319,7 +320,7 @@ app.post('/snap', [
         try {
           // Access the Chromium instance by either launching or connecting to
           // Puppeteer.
-          browser = await connectPuppeteer();
+          const browser = await connectPuppeteer();
 
           // Instead of initializing Puppeteer here, we set up a browser context
           // (think of it as a new tab in the browser). This context arg should


### PR DESCRIPTION
This PR introduces the ability to make more than one simultaneous request. While not perfect, it seems to work for N-1 simultaneous requests. That suggests to me that the issue lies somewhere in the code I wrote, not in the dependencies.

To sum up the changes using a desktop computer as an analogy, before the PR we were effectively launching a new Chrome each time a Snap was requested, and now we're just opening a new incognito tab each time a Snap comes in.

At any rate, I moved the init code to a function. When it runs the first time, the Puppeteer API outputs a connection string, and any subsequent run will reuse that connection. Then, down where we used to have initialization, we open a "context" which is a sandboxed session. I used millisecond timestamp plus the querystring to create uniqueness. If two requests happen at the same millisecond with 100% identical params then it would probably do something weird.

My non-scientific testing included "mashing the button on my HTTP request tool" and watching the logs of my local Snap Service. The process can now recover from errors and timeouts, which wasn't happening before. The requests are non-blocking, by that I mean slow jobs requested before fast ones don't stop the fast one from finishing first.