### PR TITLE
SNAP-31: release resources

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -331,13 +331,9 @@ app.post('/snap', [
           // Puppeteer.
           const browser = await connectPuppeteer();
 
-          // Instead of initializing Puppeteer here, we set up a browser context
-          // (think of it as a new tab in the browser). This context arg should
-          // be unique. Timestamp + querystring is random enough for our case.
-          const browserContext = `${startTime}${url.parse(req.url).query}`;
-
-          // New Puppeteer tab
-          const page = await browser.newPage({ context: browserContext });
+          // New Puppeteer Incognito context and create a new page within.
+          const context = await browser.createIncognitoBrowserContext();
+          const page = await context.newPage();
 
           // Set duration until Timeout
           await page.setDefaultNavigationTimeout(60 * 1000);
@@ -389,6 +385,7 @@ app.post('/snap', [
           }
 
           // Disconnect from Puppeteer process
+          await context.close();
           await browser.disconnect();
         }
         catch (err) {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-31

I believe this does the trick! Ran a bunch of snaps and instead of an ever-increasing pile, I get just three seemingly permanent processes for Chrome:

- `--type=zygote`
- `--type=gpu-process`
- `--type=renderer`

I believe the `renderer` process is a dormant "tab" which _maayyybe_ is a consequence of initiating the Chromium connection itself? Not sure. But I was able to see all the other `renderer` processes appearing and disappearing with the code in PR as Snaps get created and finish executing.

I manually ran about five at a time and never had any crash. It seems able to handle the same load as before, at least according to my very unscientific testing.