### PR TITLE
SNAP-20: set browser cookies when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Shared service to generate PNG/PDF snapshots of our websites.
 - `logo` — (optional) Display your site's logo in the header area of each page on your PDF. See [Custom Logos](#custom-logos) section for instructions on adding your logo to this repository.
 - `user` — (optional) HTTP Basic Authentication username.
 - `pass` — (optional) HTTP Basic Authentication password.
+- `cookies` — (optional) a String representing browser cookies. Just send the contents of `document.cookie` and it should work.
 - `headerTitle` — (optional) Specify a Header Title for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 - `headerSubtitle` — (optional) Specify a Header Subtitle for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 - `headerDescription` — (optional) Specify a Header Description for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.

--- a/app/app.js
+++ b/app/app.js
@@ -142,6 +142,7 @@ app.post('/snap', [
   const fnFormat = req.query.format || 'A4';
   const fnAuthUser = req.query.user || '';
   const fnAuthPass = req.query.pass || '';
+  const fnCookies = req.query.cookies || '';
   const fnSelector = req.query.selector || '';
   const fnFullPage = (fnSelector) ? false : true;
   const fnLogo = req.query.logo || false;
@@ -349,6 +350,27 @@ app.post('/snap', [
 
           // Set CSS Media
           await page.emulateMedia(fnMedia);
+
+          // Compile cookies. We have to manually specify some extra info such
+          // as host/path in order to create a valid cookie.
+          let cookies = [];
+          fnCookies.split('; ').map((cookie) => {
+            let thisCookie = {};
+            const [name, value] = cookie.split('=');
+
+            thisCookie.url = fnUrl;
+            thisCookie.name = name;
+            thisCookie.value = value;
+
+            cookies.push(thisCookie);
+          });
+
+          // Set cookies.
+          cookies.forEach(async function(cookie) {
+            await page.setCookie(cookie).catch((err) => {
+              log.error(err);
+            });
+          })
 
           // We need to load the HTML differently depending on whether it's HTML
           // in the POST or a URL in the querystring.


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-20

![cookie-monster](https://user-images.githubusercontent.com/254753/50027290-567b1000-ffb1-11e8-9bb5-7ffcf26cdc70.gif)

This PR grants requesting services the ability to send the browser cookies along in order to retain personalization (such as chosen language) or session authentication. Cookies are totally optional.

I assume for legacy reasons related to either Netscape or IE6, that cookies are surprisingly uniform in their format across the various platforms and browsers. Every browser which we offer even basic support for conforms to the rather specific format I'm looking for in the code. If there was ever a problem I'm sure we can leverage some cookie parser, but it seems to be pretty standard format (cookies separated by semi+space):

```
name=value; another=value; third=value
```

For the record I checked:

- Win7 / IE11
- Win10 / Edge 18
- macOS 10.14.1 Safari
- macOS Chrome 72
- macOS Firefox 63

I tested this not only with my REST client but also against a local copy of https://github.com/UN-OCHA/reports-site/pull/108 which was the inspiration for this PR. Success was defined by getting French-language translation of "Situation Report" near the top of the PNG download, plus translated version of "Key Figures" both of which you see here (other French under each number is coming from Contentful and not subject to the language cookie being set):

![dsr-108_snap-20](https://user-images.githubusercontent.com/254753/50027682-b3c39100-ffb2-11e8-8be9-9fdceeb01145.png)
