### PR TITLE
SNAP-23: optionally localize PDF footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Shared service to generate PNG/PDF snapshots of our websites.
 - `headerSubtitle` — (optional) Specify a Header Subtitle for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 - `headerDescription` — (optional) Specify a Header Description for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
 - `footerText` — (optional) Specify custom Footer text for each page of the PDF. ASCII characters allowed, and input will be HTML-encoded.
+- `locale` — (optional) Localizes the dynamically generated PDF footer strings (pagination and creation date). See [Localization](#localization) for locale options and defaults.
 
 We do our best to validate your input. When found to be invalid, we return **HTTP 422 Unprocessable Entity** and the response body will be a JSON object containing all failed validations.
 
@@ -60,6 +61,13 @@ html[class^='snap'] .my-selector {
 ```
 
 This class can be used anywhere in your CSS, including within Media Queries (e.g. `@media print`, `@media screen and (min-width: 700px)`, etc).
+
+### Localization
+
+We currently support the following localizations for PDF footers:
+
+- `en` (default)
+- `fr`
 
 ### Custom Logos
 

--- a/app/app.js
+++ b/app/app.js
@@ -36,6 +36,9 @@ require('./config');
 // the possible values and give a more informative validation error.
 const logos = require('./logos/_list.json');
 
+// Our list of officially supported translations.
+const locales = require('./locales/_list.json');
+
 // It's impossible to regex a CSS selector so we'll assemble a list of the most
 // common characters. Feel free to add to this list if it's preventing a legitimate
 // selector from being used. The space at the beginning of this string is intentional.
@@ -113,6 +116,7 @@ app.post('/snap', [
   query('user', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
+  query('locale', `Must be one of the following language codes: ${Object.keys(locales).join(', ')}`).optional().isIn(Object.keys(locales)),
   sanitize('headerTitle').escape(),
   sanitize('headerSubtitle').escape(),
   sanitize('headerDescription').escape(),
@@ -150,6 +154,8 @@ app.post('/snap', [
   const fnHeaderSubtitle = req.query.headerSubtitle || '';
   const fnHeaderDescription = req.query.headerDescription || '';
   const fnFooterText = req.query.footerText || '';
+  const fnLocale = req.query.locale || 'en';
+  const t = require(`./locales/${fnLocale}.js`);
 
   let fnHtml = '';
   let pngOptions = {};
@@ -214,11 +220,11 @@ app.post('/snap', [
             footerTemplate: `
               <footer class="pdf-footer">
                 <div class="pdf-footer__left">
-                  Page <span class="pageNumber"></span> of <span class="totalPages"></span>
+                  ${t['Page']} <span class="pageNumber"></span> ${t['of']} <span class="totalPages"></span>
                 </div>
                 <div class="pdf-footer__right">
                   <span class="pdf-footer__text">${fnFooterText}</span><br>
-                  Date of Creation: <span>${moment().format('D MMM YYYY')}</span><br>
+                  ${t['Date of Creation']}: <span>${moment().locale(fnLocale).format('ll')}</span><br>
                 </div>
               </footer>
               <style type="text/css">

--- a/app/locales/_list.json
+++ b/app/locales/_list.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "filename": "en.js"
+  },
+  "fr": {
+    "filename": "fr.js"
+  }
+}

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1,0 +1,15 @@
+module.exports = {
+  // System
+  'lang': 'en',
+  'lang-name': 'English',
+
+  // Global
+  'UN OCHA': 'UN OCHA',
+  'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
+
+  // Sharing
+  'Date': 'Date',
+  'Date of Creation': 'Date of creation',
+  'Page': 'Page',
+  'of': 'of',
+}

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -1,0 +1,15 @@
+module.exports = {
+  // System
+  'lang': 'fr',
+  'lang-name': 'Français',
+
+  // Global
+  'UN OCHA': 'UN OCHA',
+  'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
+
+  // Sharing
+  'Date': 'Date',
+  'Date of Creation': 'Date de création',
+  'Page': 'Page',
+  'of': 'de',
+}


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-23

Makes the changes necessary to localize the PDF footer. The header is powered by open-ended text input and the requesting service is responsible for providing whatever localized text it wants.

However, the pagination and creation date are supplied by Snap Service and required different treatment. If there is a language that doesn't match the current setup, we'll revisit. But the languages we have on hand work with a pretty minimal PR.