### PR TITLE
SNAP-23: PDF date label

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Shared service to generate PNG/PDF snapshots of our websites.
 **Parameters:**
 
 - `url` — (**required**) the URL you want to render.
-- `service` - (**recommended**) an alphanumeric identifier for the requesting service.
+- `service` — (**recommended**) an alphanumeric identifier for the requesting service. You can more easily generate usage reports by specifying the requesting service.
 - `output` — (default `pdf`) specify `png` if you want a PNG image or `pdf` for PDF.
 - `media` — (default `screen`) specify a CSS Media. Only other option is `print`.
 - `width` — (default `800`) specify a pixel value for the viewport width.

--- a/app/app.js
+++ b/app/app.js
@@ -252,7 +252,7 @@ app.post('/snap', [
                 </div>
                 <div class="pdf-footer__right">
                   <span class="pdf-footer__text">${fnFooterText}</span><br>
-                  ${t['Date of Creation']}: <span>${moment().locale(fnLocale).format('D MMM YYYY')}</span><br>
+                  ${t['Downloaded']}: <span>${moment().locale(fnLocale).format('D MMM YYYY')}</span><br>
                 </div>
               </footer>
               <style type="text/css">

--- a/app/app.js
+++ b/app/app.js
@@ -5,7 +5,8 @@
  * Accepts POST requests to /snap with either a HTTP file upload sent with
  * the name "html" or body form data with HTML content in a field named "html".
  *
- * The service will run hrome and return the generated PDF or PNG data.
+ * Alternatively, we accept a `url` parameter which will render an arbitrary
+ * web page on the internet.
  *
  * This service is not meant to be exposed to the public, and use of this
  * service should be mediated by another application with access controls.

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -10,6 +10,7 @@ module.exports = {
   // Sharing
   'Date': 'Date',
   'Date of Creation': 'Date of creation',
+  'Downloaded': 'Downloaded',
   'Page': 'Page',
   'of': 'of',
 }

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -10,6 +10,7 @@ module.exports = {
   // Sharing
   'Date': 'Date',
   'Date of Creation': 'Date de création',
+  'Downloaded': 'Téléchargé le',
   'Page': 'Page',
   'of': 'de',
 }


### PR DESCRIPTION
During a planning meeting it was decided to change "Date of Creation" to "Downloaded" in order to reduce confusion involving two different dates.

Now the PDF footer says "Downloaded" and the PDF header can still say whatever it wants.