### PR TITLE
SNAP-41: support Puppeteer printBackground param

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Shared service to generate PNG/PDF snapshots of our websites.
   - `A5`: 5.83in x 8.27in
   - `A6`: 4.13in x 5.83in
 - `pdfLandscape` — (default `false`) a Boolean indicating whether the PDF should be Landscape. Defaults to Portrait.
+— `pdfBackground` — (default `false`) a Boolean indicating whether the PDF should print any CSS related to backgrounds. This includes colors, images, and so forth. Equivalent to the `printBackground` parameter of `page.pdf()`.
 - `pdfHeader` — (optional) inline HTML/CSS to construct a 100% custom PDF Header. The [Puppeteer PDF documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions) contains additional information regarding pagination and other metadata you might want to dynamically generate. It's listed under `headerTemplate` property.
 - `pdfFooter` — (optional) all capabilities, limitations, and documentation references are identical to `pdfHeader`
 - `selector` — (optional) specify a CSS selector. Snap Service will return ONLY the first element which matches your selector.

--- a/app/app.js
+++ b/app/app.js
@@ -120,6 +120,7 @@ app.post('/snap', [
   query('selector', `Must be a CSS selector made of the following characters: ${allowedSelectorChars}`).optional().isWhitelisted(allowedSelectorChars),
   query('pdfFormat', `Must be one of the following values: ${allowedFormats.join(', ')}`).optional().isIn(allowedFormats),
   query('pdfLandscape', 'Must be one of the following: true, false').optional().isBoolean(),
+  query('pdfBackground', 'Must be one of the following: true, false').optional().isBoolean(),
   query('user', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
@@ -147,7 +148,8 @@ app.post('/snap', [
   const fnMedia = req.query.media || 'screen';
   const fnOutput = req.query.output || 'pdf';
   const fnPdfFormat = req.query.pdfFormat || 'A4';
-  const fnPdfLandscape = Boolean(req.query.pdfLandscape) || false;
+  const fnPdfLandscape = Boolean(req.query.pdfLandscape === 'true') || false;
+  const fnPdfBackground = Boolean(req.query.pdfBackground === 'true') || false;
   const fnAuthUser = req.query.user || '';
   const fnAuthPass = req.query.pass || '';
   const fnCookies = req.query.cookies || '';
@@ -234,6 +236,7 @@ app.post('/snap', [
             path: tmpPath,
             format: fnPdfFormat,
             landscape: fnPdfLandscape,
+            printBackground: fnPdfBackground,
             displayHeaderFooter: !!fnPdfHeader || !!fnPdfFooter,
             headerTemplate: fnPdfHeader,
             footerTemplate: fnPdfFooter,


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-41

Puppeteer avoids printing CSS related to `background-*` by default. It can be enabled with one param and this PR allows folks to use it.

I noticed I had incorrectly implemented the Boolean for `pdfLandscape` and the fix is in this branch.