### PR TITLE
[SNAP-53] Expand the permitted characters in the service param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you do not specify either of these, Snap Service will return **`HTTP 400 Bad 
 
 Send any combination of the following as querystring parameters:
 
-- `service` — (**recommended**) an alphanumeric identifier for the requesting service. You can more easily generate usage reports by specifying the requesting service. Must be an alphanumeric string such as `dsreports` or `hrinfo`.
+- `service` — (**recommended**) an identifier for the requesting service. You can more easily generate usage reports by specifying the requesting service. Must be an alphanumeric string (plus . _ -)such as `dsreports`, `hrinfo` or `hid-api`.
 - `output` — (default `pdf`) specify `png` if you want a PNG image or `pdf` for PDF.
 - `media` — (default `screen`) specify a CSS Media. Only other option is `print`.
 - `width` — (default `800`) specify a pixel value for the viewport width.

--- a/app/app.js
+++ b/app/app.js
@@ -133,7 +133,7 @@ app.post('/snap', [
   query('user', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
-  query('service', 'Must be an alphanumeric string identifier for the requesting service.').optional().isAlphanumeric(),
+  query('service', `Must be an alphanumeric (plus ._-) string identifier for the requesting service. Must match /^[\.0-9A-z_-]+$/.`).optional().matches(/^[\.0-9A-z_-]+$/),
   query('ua', '').optional(),
 ], (req, res) => {
   // debug


### PR DESCRIPTION
This way, properties that have hyphenated names can pass that name directly. Also allow full stops and underscores.

The service parameter is now validated using a regex.