### PR TITLE
[SNAP-44] Error out if html and url are both present or both absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ One of the following two inputs is **required**:
 - `url` — (querystring parameter) the remote URL you want to render.
 - `html` — (urlencoded form data) the URL-encoded HTML you want to render.
 
-If you do not specify either of these, Snap Service will return **`HTTP 400 Bad Request`**.
+If you do not specify either of these, Snap Service will return **`HTTP 422 Unprocessable Entity`**.
 
 ### Parameters
 

--- a/app/app.js
+++ b/app/app.js
@@ -139,9 +139,9 @@ app.post('/snap', [
   // debug
   log.debug({ 'query': url.parse(req.url).query }, 'Request received');
 
-  // If neither `url` and `html` are present, return 400 requiring valid input.
+  // If neither `url` and `html` are present, return 422 requiring valid input.
   if (!req.query.url && !req.body.html) {
-    return res.status(400).json({ errors: [
+    return res.status(422).json({ errors: [
       {
         'location': 'query',
         'param': 'url',
@@ -157,9 +157,9 @@ app.post('/snap', [
     ]});
   }
 
-  // If both `url` and `html` are present, return 400 requiring valid input.
+  // If both `url` and `html` are present, return 422 requiring valid input.
   if (req.query.url && req.body.html) {
-    return res.status(400).json({ errors: [
+    return res.status(422).json({ errors: [
       {
         'location': 'query',
         'param': 'url',


### PR DESCRIPTION
A validation error *must* return HTTP status 422, or the keepalived check script will detect the service as down.

I think this is better than simply throwing a 400, for the same reasons that lead us to choose 422 originally for validation errors on optional parameters. But if need be, I can modify the check script to accept `400 <= status < 500` as "up" instead.