### PR TITLE
SNAP-54: remove magic DSR number from pdfHeader+logo scenario

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -346,9 +346,6 @@ app.post('/snap', [
               height: imgSize(pdfLogoFile).height * .75,
             };
 
-            // TODO: margin-top calculation is DSR-specific logic that should be
-            //       amended using the new pdfMargin params once they're shipped
-            pdfOptions.margin.top = imgSize(pdfLogoFile).height + 84 + 'px';
             pdfOptions.headerTemplate = fnPdfHeader
               .replace('__LOGO_SRC__', pdfLogo.src)
               .replace('__LOGO_WIDTH__', pdfLogo.width)


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/SNAP-54

Remove DSR-specific code. We're now explicitly setting: https://github.com/UN-OCHA/reports-site/pull/246