### PR TITLE
[OPS-6072] Bump the base image (and builder) to the one with the Noto fonts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM unocha/debian-snap-base:10-buster-node12-201911-01 as builder
+FROM unocha/debian-snap-base:10-buster-chrome80-node12-201912-01 as builder
 
 WORKDIR /srv/src
 COPY . .
@@ -9,7 +9,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN cd app && \
     npm install
 
-FROM unocha/debian-snap-base:10-buster-node12-201911-01
+FROM unocha/debian-snap-base:10-buster-chrome80-node12-201912-01
 
 WORKDIR "${NODE_APP_DIR}"
 

--- a/app/app.js
+++ b/app/app.js
@@ -339,7 +339,7 @@ app.post('/snap', [
           if (logos.hasOwnProperty(fnLogo)) {
             hasLogo = true;
             const pdfLogoFile = __dirname + '/logos/' + logos[fnLogo].filename;
-            const pdfLogoData = new Buffer(fs.readFileSync(pdfLogoFile, 'binary'));
+            const pdfLogoData = new Buffer.from(fs.readFileSync(pdfLogoFile, 'binary'));
             const pdfLogo = {
               src: `data:${mime.lookup(pdfLogoFile)};base64,${pdfLogoData.toString('base64')}`,
               width: imgSize(pdfLogoFile).width * .75,


### PR DESCRIPTION
See https://github.com/UN-OCHA/docker-images/pull/224