### PR TITLE
[SNAP-42] Migrate HDX to shard snap service

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -132,7 +132,7 @@ app.get('/status', (req, res) => res.status(204).send());
 // Snaps
 app.post('/snap', [
   body('html', '').optional(),
-  query('url', 'Must be a valid, fully-qualified URL').optional().isURL({ require_protocol: true, disallow_auth: true }),
+  query('url', 'Must be a valid, fully-qualified URL').optional().isURL({ require_protocol: true, disallow_auth: true, validate_length: false }),
   query('width', 'Must be an integer with no units').optional().isInt(),
   query('height', 'Must be an integer with no units').optional().isInt(),
   query('scale', 'Must be an integer in the range: 1-3').optional().isInt({ min: 1, max: 3 }),

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "bunyan": "^1.8.12",
     "debug": "3.1.0",
     "express": "^4.16.3",
-    "express-validator": "^5.3.0",
+    "express-validator": "^6.6.1",
     "he": "^1.2.0",
     "image-size": "^0.6.3",
     "kind-of": "^6.0.3",


### PR DESCRIPTION
It turns out the "invalid_url" error is due to https://github.com/validatorjs/validator.js trying to be nice to Internet Explorer and cutting strings to 2083 chars.

This is used by https://github.com/express-validator/express-validator used by snap to check the validity of URLs.

This PR is overloading isUrl method of express-validator with the validate_length param (which eventually gets to the validator.js isUrl method).

Thanks to @aalecs for help.

```validate_length - if set as false isURL will skip string length validation (2083 characters is IE max URL length).```