### PR TITLE
[HOTFIX] Remove chrome unstable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
     # Install Chrome, so it can match
     apt-get update && \
-    apt-get -qy install --no-install-recommends google-chrome-stable && \
+    apt-get -qy install --no-install-recommends google-chrome-stable google-chrome-unstable- && \
     # Ok, cleanup!
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Keep only one chrome, so there is no chance of helpers of libraries messing things up.