### PR TITLE
[OPS-7153] Check a passed url against a list of permitted hostnames.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -198,16 +198,19 @@ app.post('/snap', [
     ]});
   }
 
-  // Ensure a passed url is on the permitted list.
+  // Ensure a passed url is on the permitted list or includes a substring that is on the permitted list.
   if (req.query.url) {
     const urlHash = new URL(req.query.url);
-    if (!allowedHostnames.includes(urlHash.hostname)) {
+
+    // Check if any of the allowed hostnames are a substring of the url.hostname.
+    // This allowed a domain suffix match as well as a full hostname match.
+    if (!allowedHostnames.some(allowedHost => urlHash.hostname.includes(allowedHost))) {
       return res.status(422).json({ errors: [
         {
           'location': 'query',
           'param': 'url',
           'value': urlHash.hostname,
-          'msg': 'The supplied `url.hostname` is not on the list of allowed hostnames.',
+          'msg': 'The supplied `url.hostname` does not match any allowed hostname.',
         }
       ]});
     }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-snap-service",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",


### PR DESCRIPTION
Refuse to snap if the host is not listed.

```
docker-compose.yml:
  environment:
      - MAX_CONCURRENT_REQUESTS=${MAX_CONCURRENT_REQUESTS:-2}
      - ALLOWED_HOSTNAMES=localhost,www.google.com

cafuego@calvados:~/Development/unocha/tools-snap-service (cafuego/ops-7153-snap-safety *$)
; curl -XPOST http://127.0.0.1:8442/snap?url=https://www.disney.com
{"errors":[{"location":"query","param":"url.hostname","value":"www.disney.com","msg":"The supplied `url` is not on the list of allowed hostnames."}]}

cafuego@calvados:~/Development/unocha/tools-snap-service (cafuego/ops-7153-snap-safety *$)
; curl -XPOST http://127.0.0.1:8442/snap?url=https://www.google.com
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
```