### PR TITLE
SNAP-88: downgrade puppeteer to 6.0.0 to stave off the breaking change

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -370,7 +370,7 @@ app.post('/snap', [
             },
           };
 
-          // Do string substitution on the fnPdfHeader is the logo was specified.
+          // Do string substitution on the fnPdfHeader if the logo was specified.
           if (logos.hasOwnProperty(fnLogo)) {
             hasLogo = true;
             const pdfLogoFile = __dirname + '/logos/' + logos[fnLogo].filename;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-snap-service",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -969,9 +969,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "devtools-protocol": {
-      "version": "0.0.854822",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
-      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg=="
+      "version": "0.0.842839",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.842839.tgz",
+      "integrity": "sha512-iI3v9uuGUW02vPUXTvxl4ijnCPL/RGRVR9I+U8s7+9OG9An/bvExjQ0KrXE9V0QBLra7wANhZctB00FKBSn1gw=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -3152,18 +3152,18 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
-      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-6.0.0.tgz",
+      "integrity": "sha512-LqDbNC7rp0JNH7BRTPjE3lCzGYD2tFqWBvRNukW4PjRP2YotWZWeLfFMTGrDHDFY5xjOceKBEbf8h45Xn6DFdw==",
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.854822",
+        "devtools-protocol": "0.0.842839",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
-        "proxy-from-env": "^1.1.0",
+        "proxy-from-env": "^1.0.0",
         "rimraf": "^3.0.2",
         "tar-fs": "^2.0.0",
         "unbzip2-stream": "^1.3.3",
@@ -3233,11 +3233,6 @@
           "requires": {
             "find-up": "^4.0.0"
           }
-        },
-        "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
         }
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",
@@ -24,7 +24,7 @@
     "mime-types": "^2.1.20",
     "moment": "^2.22.2",
     "pm2": "^4.5.5",
-    "puppeteer": "8.0.0",
+    "puppeteer": "6.0.0",
     "set-value": ">=2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# SNAP-88

This is a downgrade of puppeteer from 8.0.0 to 6.0.0 in order to avoid breaking changes that affected at least one team during our dev testing period.

