### PR TITLE
SNAP-90: log UA into ELK when connecting to Chromium

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -98,6 +98,11 @@ async function connectPuppeteer() {
       dumpio: false, // set to `true` for debugging
     });
 
+    // Log UA for visibility in ELK.
+    const ua = await browser.userAgent();
+    log.info(`New connection to Chrome. UA: ${ua}`);
+
+    // Create re-usable connection.
     browserWSEndpoint = browser.wsEndpoint();
   }
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",


### PR DESCRIPTION
# SNAP-90

Our deploy went poorly and we have to rebuild the image. While doing so I thought why not make this local log statement permanent, so that we can easily see in Kibana what Chromium we're connecting to (if any).