### PR TITLE
SNAP-90: more error handling

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -607,7 +607,7 @@ app.post('/snap', [
             const duration = ((Date.now() - startTime) / 1000);
             res.end();
             lgParams.duration = duration
-            log.info(lgParams, `PNG ${tmpPath} successfully generated in ${duration} seconds.`);
+            log.info(lgParams, `PNG successfully generated in ${duration} seconds.`);
             return fs.unlink(tmpPath, cb);
           });
         } else {
@@ -616,7 +616,7 @@ app.post('/snap', [
             const duration = ((Date.now() - startTime) / 1000);
             res.end();
             lgParams.duration = duration
-            log.info(lgParams, `PDF ${tmpPath} successfully generated in ${duration} seconds.`);
+            log.info(lgParams, `PDF successfully generated in ${duration} seconds.`);
             return fs.unlink(tmpPath, cb);
           });
         }

--- a/app/app.js
+++ b/app/app.js
@@ -63,13 +63,6 @@ function ated(request) {
          (request.connection.socket ? request.connection.socket.remoteAddress : null);
 }
 
-// Launch Puppeteer.
-//
-// Using the launch() command multiple times results in multiple Chromium procs
-// but (just like a normal web browser) we only want one. We'll open a new "tab"
-// each time our `/snap` route is invoked by reusing the established connection.
-let browserWSEndpoint = '';
-
 /**
  * A semaphore to limit the maximum number of concurrent active requests to
  * puppeteer, and require that new requests wait until previous ones are
@@ -77,36 +70,48 @@ let browserWSEndpoint = '';
  */
 const PUPPETEER_SEMAPHORE = new Semaphore(process.env.MAX_CONCURRENT_REQUESTS || 4);
 
+/**
+ * Launch Puppeteer.
+ *
+ * Using the launch() command multiple times results in multiple Chromium procs
+ * but (just like a normal web browser) we only want one. We'll open a new "tab"
+ * each time our `/snap` route is invoked by reusing the established connection.
+ */
+let browserWSEndpoint = '';
+
 async function connectPuppeteer() {
-  let browser;
+  try {
+    let browser;
 
-  if (browserWSEndpoint) {
-    browser = await puppeteer.connect({browserWSEndpoint});
+    if (browserWSEndpoint) {
+      browser = await puppeteer.connect({browserWSEndpoint});
+    } else {
+      // Initialize Puppeteer
+      browser = await puppeteer.launch({
+        executablePath: '/usr/bin/google-chrome',
+        args: [
+          '--headless',
+          '--disable-gpu',
+          '--remote-debugging-port=9222',
+          '--remote-debugging-address=0.0.0.0',
+          '--no-sandbox',
+          '--disable-dev-shm-usage',
+        ],
+        dumpio: false, // set to `true` for debugging
+      });
+
+      // Log UA for visibility in ELK.
+      const ua = await browser.userAgent();
+      log.info(`New connection to Chrome. UA: ${ua}`);
+
+      // Create re-usable connection.
+      browserWSEndpoint = browser.wsEndpoint();
+    }
+
+    return browser;
+  } catch (err) {
+    throw err;
   }
-  else {
-    // Initialize Puppeteer
-    browser = await puppeteer.launch({
-      executablePath: '/usr/bin/google-chrome',
-      args: [
-        '--headless',
-        '--disable-gpu',
-        '--remote-debugging-port=9222',
-        '--remote-debugging-address=0.0.0.0',
-        '--no-sandbox',
-        '--disable-dev-shm-usage',
-      ],
-      dumpio: false, // set to `true` for debugging
-    });
-
-    // Log UA for visibility in ELK.
-    const ua = await browser.userAgent();
-    log.info(`New connection to Chrome. UA: ${ua}`);
-
-    // Create re-usable connection.
-    browserWSEndpoint = browser.wsEndpoint();
-  }
-
-  return browser;
 }
 
 // Set up the Express app
@@ -400,7 +405,9 @@ app.post('/snap', [
           try {
             // Access the Chromium instance by either launching or connecting to
             // Puppeteer.
-            const browser = await connectPuppeteer();
+            const browser = await connectPuppeteer().catch(err => {
+              throw err;
+            });
 
             // New Puppeteer Incognito context and create a new page within.
             const context = await browser.createIncognitoBrowserContext();
@@ -583,7 +590,7 @@ app.post('/snap', [
             await browser.disconnect();
           }
           catch (err) {
-            throw new Error(err);
+            throw err;
           }
         });
       }
@@ -623,9 +630,11 @@ app.post('/snap', [
     const duration = ((Date.now() - startTime) / 1000);
 
     if (err) {
-      lgParams.duration = duration
-      log.warn(lgParams, `Snap FAILED in ${duration} seconds. ${err}`);
-      res.status(500).send('' + err);
+      lgParams.fail = true;
+      lgParams.stack_trace = err.stack;
+      lgParams.duration = duration;
+      log.error(lgParams, `Snap FAILED in ${duration} seconds. ${err}`);
+      res.status(500).send('Internal Server Error');
     }
   });
 });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-snap-service",
-  "version": "2.6.4",
+  "version": "2.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -274,9 +274,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
       "optional": true
     },
     "@types/yauzl": {
@@ -772,7 +772,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "concat-map": {
@@ -3559,11 +3559,18 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "strip-ansi": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",


### PR DESCRIPTION
# SNAP-90

Trying to produce more errors during startup in order to help debug our prod-only failures from the last two weeks. I did small cleanups to also hide any 500s from the end-user themselves, and used the conventions from HID to standardize some logging fields. Not sure if they have to be added to Kibana indexer but the new fields are:

```js
{
  fail: true, // Boolean
  stack_trace: "", // String
}
```

Tagging @cafuego for eventual review, but merging in order to tag while the Chrome stable download is identical/similar to the package I downloaded while building+testing locally.