### PR TITLE
[SNAP-90] Do not try to re-add the repo, as the base image already configures it.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+etc
+var

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,9 @@ ENV NODE_APP_DIR=/srv/www \
     PORT=8442
 
 RUN \
-    # Configure Chrome repo.
-    curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub -o linux_signing_key.pub && \
-    apt-key add linux_signing_key.pub && \
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    # Install Chrome, so it can match
+    # Install Chrome, so it can match. The base image already has the repo.
     apt-get update && \
+    apt-get -qy dist-upgrade && \
     apt-get -qy install --no-install-recommends google-chrome-stable && \
     # Ok, cleanup!
     apt-get clean && \


### PR DESCRIPTION
The base image is now also more up to date and no longer contains chrome
(stable or unstable) so it all gets a bit smaller, neater and faster to
build, push and pull.


See https://github.com/UN-OCHA/docker-images/pull/272