### PR TITLE
[SNAP-91] monthly Chrome bump

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-snap-service",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -274,9 +274,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
       "optional": true
     },
     "@types/yauzl": {
@@ -906,9 +906,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "devtools-protocol": {
-      "version": "0.0.854822",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
-      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg=="
+      "version": "0.0.869402",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+      "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -3022,12 +3022,12 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
-      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.0.0.tgz",
+      "integrity": "sha512-Avu8SKWQRC1JKNMgfpH7d4KzzHOL/A65jRYrjNU46hxnOYGwqe4zZp/JW8qulaH0Pnbm5qyO3EbSKvqBUlfvkg==",
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.854822",
+        "devtools-protocol": "0.0.869402",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",
@@ -24,7 +24,7 @@
     "mime-types": "^2.1.20",
     "moment": "^2.22.2",
     "pm2": "^4.5.6",
-    "puppeteer": "8.0.0",
+    "puppeteer": "9.0.0",
     "set-value": ">=2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# SNAP-91

Monthly updates:

- Chromium 91.0.4472.77-1
- UA: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/91.0.4472.77 Safari/537.36","time":"2021-05-31T08:36:27.039Z`
- Puppeteer 9.0.0