### PR TITLE
[SNAP-91] second version bump

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-snap-service",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",


### PR DESCRIPTION
# SNAP-91

Version bump, nothing else. See #127 for code changes.

Our troubles in the previous month required multiple bumps and the codebase got out of sync with docker image tags.