### PR TITLE
[SNAP-80] Keep track of used semaphores, so the status handler can re…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ docker-compose build
 docker-compose up
 ```
 
-Now you can `POST` to `localhost:8442/snap` and it should return Snaps to you. There's also a `/status` route for pingdom that you can `GET` in order to quickly confirm it's up and running:
+Now you can `POST` to `localhost:8442/snap` and it should return Snaps to you. There's also a `/status` route for pingdom that you can `GET` in order to quickly confirm it's up and running and not at its concurreny limit:
 
 ```sh
-# Ping the service to confirm server is running. HTTP 204 is success.
-curl -I http://localhost:8442/status
+# Ping the service to confirm server is running. HTTP 200 is success, the response body shows the number of in-flight snap requests.
+curl -X GET http://localhost:8442/status
 
 # Snap a PDF of example.com and save to tmp.pdf
 curl -X POST http://localhost:8442/snap?url=https://example.com > tmp.pdf

--- a/app/app.js
+++ b/app/app.js
@@ -144,7 +144,7 @@ app.get('/status', (req, res) => {
   if (inFlightRequests <= semaphoreSize) {
     res.status(200).send(`Healthy. There are ${inFlightRequests}/${process.env.MAX_CONCURRENT_REQUESTS} requests in flight.`);
   } else {
-    res.status(507).send(`Unhealthy. There are ${inFlightRequests}/${process.env.MAX_CONCURRENT_REQUESTS} requests in flight.`);
+    res.status(429).send(`Unhealthy. There are ${inFlightRequests}/${process.env.MAX_CONCURRENT_REQUESTS} requests in flight.`);
   }
 });
 

--- a/app/app.js
+++ b/app/app.js
@@ -138,8 +138,8 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
 app.get('/status', (req, res) => {
   // Calculate the number of in-flight requests. The semaphore count is
   // decreased by 1 for each concurrent snap, so the maths are simple.
-  let semaphoreSize = process.env.MAX_CONCURRENT_REQUESTS || 4;
-  let inFlightRequests = semaphoreSize - PUPPETEER_SEMAPHORE.count;
+  const semaphoreSize = process.env.MAX_CONCURRENT_REQUESTS || 4;
+  const inFlightRequests = semaphoreSize - PUPPETEER_SEMAPHORE.count;
 
   if (inFlightRequests <= semaphoreSize) {
     res.status(200).send(`Healthy. There are ${inFlightRequests}/${process.env.MAX_CONCURRENT_REQUESTS} requests in flight.`);

--- a/app/app.js
+++ b/app/app.js
@@ -135,7 +135,18 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
 });
 
 // Health check
-app.get('/status', (req, res) => res.status(204).send());
+app.get('/status', (req, res) => {
+  // Calculate the number of in-flight requests. The semaphore count is
+  // decreased by 1 for each concurrent snap, so the maths are simple.
+  let semaphoreSize = process.env.MAX_CONCURRENT_REQUESTS || 4;
+  let inFlightRequests = semaphoreSize - PUPPETEER_SEMAPHORE.count;
+
+  if (inFlightRequests <= semaphoreSize) {
+    res.status(200).send(`Healthy. There are ${inFlightRequests}/${process.env.MAX_CONCURRENT_REQUESTS} requests in flight.`);
+  } else {
+    res.status(507).send(`Unhealthy. There are ${inFlightRequests}/${process.env.MAX_CONCURRENT_REQUESTS} requests in flight.`);
+  }
+});
 
 // Snaps
 app.post('/snap', [


### PR DESCRIPTION
# SNAP-80

Keep track of used semaphores, so the status handler can return an error code if we are exceeding the configured amount.