### PR TITLE
SNAP-102: convert our 422s to 400s

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -178,9 +178,9 @@ app.post('/snap', [
   // debug
   log.debug('Request received', { query: url.parse(req.url).query });
 
-  // If neither `url` and `html` are present, return 422 requiring valid input.
+  // If neither `url` and `html` are present, return 400 requiring valid input.
   if (!req.query.url && !req.body.html) {
-    return res.status(422).json({
+    return res.status(400).json({
       errors: [
         {
           location: 'query',
@@ -198,9 +198,9 @@ app.post('/snap', [
     });
   }
 
-  // If both `url` and `html` are present, return 422 requiring valid input.
+  // If both `url` and `html` are present, return 400 requiring valid input.
   if (req.query.url && req.body.html) {
-    return res.status(422).json({
+    return res.status(400).json({
       errors: [
         {
           location: 'query',
@@ -239,10 +239,10 @@ app.post('/snap', [
     }
   }
 
-  // Validate input errors, return 422 for any problems.
+  // Validate input errors, return 400 for any problems.
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(422).json({ errors: errors.array() });
+    return res.status(400).json({ errors: errors.array() });
   }
 
   // Housekeeping

--- a/app/app.js
+++ b/app/app.js
@@ -226,13 +226,13 @@ app.post('/snap', [
     // Check if any of the allowed hostnames are substrings of `url.hostname`
     // This allowed a domain suffix match as well as a full hostname match.
     if (!allowedHostnames.some(allowedHost => urlHash.hostname.includes(allowedHost))) {
-      return res.status(422).json({
+      return res.status(403).json({
         errors: [
           {
             location: 'query',
             param: 'url',
             value: urlHash.hostname,
-            msg: `${urlHash.hostname} does not match any allowed hostname.`,
+            msg: `${urlHash.hostname} does not match any allowed hostname. Please file an OPS ticket if you want to allow a new hostname.`,
           },
         ],
       });


### PR DESCRIPTION
# SNAP-102

I have always been a little unsure about this, but decided with other error codes changing, we should convert these 422s to other more standard response codes that exist in HTTP 1.1 itself.

For allowed hostnames, I converted it to HTTP 403 which means it's blocked based on internal logic and re-authentication isn't possible. The error message includes a note to file an OPS ticket if they want to add a hostname to the allow-list.