### PR TITLE
SNAP-103: upgrade Chromium and prepare release

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
+## [3.0.0](https://github.com/UN-OCHA/tools-snap-service/compare/v2.8.2...v3.0.0) (2022-03-14)
+
+### ⚠ BREAKING CHANGES
+
+* return 400 instead of 422 for all validation errors ([b8fb1fc](https://github.com/UN-OCHA/tools-snap-service/commit/b8fb1fc6c515a10958b390093378e1bed5cc7b76))
+* when hostname of `url` parameter isn't in our allow-list, return 403 ([c59b0ff](https://github.com/UN-OCHA/tools-snap-service/commit/c59b0ff96d80eec0169f9b5165b65708e53c8fb4))
+* **status:** If everything is ok, we now send 200 with the number of concurrent requests, instead of the old HTTP 204. If we are at our limit for concurrent requests, we send HTTP 429. Refs: SNAP-80
+
+### Features
+
+* return HTTP 405 for any `GET` request to /snap ([fd0d29d](https://github.com/UN-OCHA/tools-snap-service/commit/fd0d29d94ba7c3d46383190378bb7c232ec2dd00))
+
+### Bug Fixes
+
+* upgrade puppteer to match latest Chromium stable ([369ea02](https://github.com/UN-OCHA/tools-snap-service/commit/369ea02b0a1c9600435b085b42588a290af5ce44))
+
+
 ### [2.8.2](https://github.com/UN-OCHA/tools-snap-service/compare/v2.8.1...v2.8.2) (2022-01-31)
 
 - **security**: update ansi-regex ([3cbd72f](https://github.com/UN-OCHA/tools-snap-service/commit/3cbd72f35b308fb8cff9c63549ca18c1c535d208))

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -318,9 +318,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
-      "integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "optional": true
     },
     "@types/normalize-package-data": {
@@ -1437,9 +1437,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.948846",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.948846.tgz",
-      "integrity": "sha512-5fGyt9xmMqUl2VI7+rnUkKCiAQIpLns8sfQtTENy5L70ktbNw0Z3TFJ1JoFNYdx/jffz4YXU45VF75wKZD7sZQ=="
+      "version": "0.0.960912",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.960912.tgz",
+      "integrity": "sha512-I3hWmV9rWHbdnUdmMKHF2NuYutIM2kXz2mdXW8ha7TbRlGTVs+PF+PsB5QWvpCek4Fy9B+msiispCfwlhG5Sqg=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -3037,7 +3037,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4126,12 +4126,12 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.1.2.tgz",
-      "integrity": "sha512-ozVM8Tdg0patMtm/xAr3Uh7rQ28vBpbTHLP+ECmoAxG/s4PKrVLN764H/poLux7Ln77jHThOd8OBJj5mTuA6Iw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.2.0.tgz",
+      "integrity": "sha512-OSRcIgPq78Cjysm4AOvGgGN464qugfYZ1bJRpPZ7d6c2P/zVQmACblIiB56frVoSuHpvqo+ZphFJo7kF9V5iEg==",
       "requires": {
-        "debug": "4.3.2",
-        "devtools-protocol": "0.0.948846",
+        "debug": "4.3.3",
+        "devtools-protocol": "0.0.960912",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
         "node-fetch": "2.6.7",
@@ -4145,9 +4145,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-snap-service",
-  "version": "2.8.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "2.8.2",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "method-override": "^3.0.0",
     "mime-types": "^2.1.20",
     "pm2": "^5.1.0",
-    "puppeteer": "13.1.2"
+    "puppeteer": "13.2.0"
   },
   "devDependencies": {
     "eslint": "^8.8.0",


### PR DESCRIPTION
# SNAP-103

Upgrades puppeteer to match latest stable Chromium, and includes release notes for this week's deploy.