### PR TITLE
[SNAP-106] ensure future releases skip creation of git tag

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,5 +29,10 @@
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.14.0",
     "standard-version": "^9.3.2"
+  },
+  "standard-version": {
+    "skip": {
+      "tag": true
+    }
   }
 }


### PR DESCRIPTION
# SNAP-106

Since we manage the tags via GitHub Releases, we don't want our command-line tool to make tags for us.
