### PR TITLE
chore: upgrade to node20

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Get deps
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/debian-snap-base:16-debian as builder
+FROM public.ecr.aws/unocha/debian-snap-base:20-debian as builder
 
 WORKDIR /srv/src
 COPY . .
@@ -10,7 +10,7 @@ RUN cd app && \
     npm install
 
 # The base image to build our app into. this already contains fonts and utilities.
-FROM public.ecr.aws/unocha/debian-snap-base:16-debian
+FROM public.ecr.aws/unocha/debian-snap-base:20-debian
 
 # Configure the service container.
 ENV NODE_APP_DIR=/srv/www \


### PR DESCRIPTION
Refs: OPS-9554

A minimum of changes, to beat the node16 EOL date.