### PR TITLE
chore(release): 3.2.9

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [3.2.8](https://github.com/UN-OCHA/tools-snap-service/compare/v3.2.7...v3.2.8) (2023-12-04)
+## [3.2.9](https://github.com/UN-OCHA/tools-snap-service/compare/v3.2.8...v3.2.9) (2024-01-15)
+
+### Bug Fixes
+
+* **security:** update Chromium/puppeteer
+
+
+## [3.2.8](https://github.com/UN-OCHA/tools-snap-service/compare/v3.2.7...v3.2.8) (2023-12-04)
 
 
 ### Bug Fixes
 
 * **security:** update Chromium/puppeteer ([cfd22a0](https://github.com/UN-OCHA/tools-snap-service/commit/cfd22a0c1d1f2320c9957f4c3e0202dfd0cb5989))
 
-### [3.2.7](https://github.com/UN-OCHA/tools-snap-service/compare/v3.2.6...v3.2.7) (2023-10-23)
+## [3.2.7](https://github.com/UN-OCHA/tools-snap-service/compare/v3.2.6...v3.2.7) (2023-10-23)
 
 
 ### Bug Fixes

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tools-snap-service",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tools-snap-service",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "dependencies": {
         "async": "^2.6.4",
         "await-semaphore": "^0.1.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tools-snap-service",
   "description": "Node.js web service interface to puppeteer/chrome for generating PDFs and PNGs from HTML.",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "scripts": {
     "start": "./node_modules/.bin/pm2 start app.js --no-daemon --watch --node-args='--max-http-header-size=16384'",


### PR DESCRIPTION
## [3.2.9](https://github.com/UN-OCHA/tools-snap-service/compare/v3.2.8...v3.2.9) (2024-01-15)

### Bug Fixes

* **security:** update Chromium/puppeteer