### PR TITLE
[SNAP-76] enforce required service param

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The URL-encoded HTML you want to render. Send with `Content-Type: application/x-
 #### `service`
 While it won't affect the output you receive from Snap Service, this parameter allows our Ops team to monitor and report your usage of the shared Snap service. It also allows us to prioritize support/feature requests.
 
-Must be an alphanumeric string (hyphens, underscores are also allowed) such as `dsreports`, `hr-info` or `hid_api`.
+Must be an alphanumeric string (hyphens, underscores are also allowed) such as `dsreports`, `hr-info` or `hid_api`. If you don't send a `service` param, or it doesn't match the formatting requirements, Snap Service will return **`HTTP 400 Bad Request`**.
 
 |Default  |Required  |Type    |
 |---------|----------|--------|

--- a/app/app.js
+++ b/app/app.js
@@ -181,7 +181,7 @@ app.post('/snap', [
   query('user', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('pass', 'Must be an alphanumeric string').optional().isAlphanumeric(),
   query('logo', `Must be one of the following values: ${Object.keys(logos).join(', ')}. If you would like to use your site's logo with Snap Service, please read how to add it at https://github.com/UN-OCHA/tools-snap-service#custom-logos`).optional().isIn(Object.keys(logos)),
-  query('service', 'Must be an alphanumeric string identifier (hyphens, underscores are also allowed).').optional().matches(/^[A-Za-z0-9_-]+$/),
+  query('service', 'Must be an alphanumeric string identifier (hyphens, underscores are also allowed).').matches(/^[A-Za-z0-9_-]+$/),
   query('ua', '').optional(),
   query('delay', 'Must be an integer between 0-10000 inclusive.').optional().isInt({ min: 0, max: 10000 }),
   query('debug', 'Must be one of the following (case insensitive): true, false').optional().toLowerCase().isBoolean(),


### PR DESCRIPTION
BREAKING CHANGE: our docs have always said the service parameter is required, but in code it was optional until now. It is now truly required.

Refs: SNAP-76