### PR TITLE
chore: Bump the actions used to current versions, so they are on a supported node version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
         ecr_github_token: ${{ secrets.ECR_GITHUB_TOKEN }}
         ecr_jenkins_token: ${{ secrets.JENKINS_ECR_TOKEN }}
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-        slack_channel_name: ${{ secrets.SLACK_CHANNEL }}
+        slack_channel_name: ${{ vars.SLACK_CHANNEL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Checkout code
       id: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Build The Thing

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '20.x'
 


### PR DESCRIPTION
Refs: SNAP-137